### PR TITLE
Rename scope states

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ use Innmind\Immutable\Sequence;
             $continuation = $continuation->carryWith([$users, $finished, $launched]);
 
             if ($finished === 2) {
-                $continuation = $continuation->terminate();
+                $continuation = $continuation->finish();
             }
 
             return $continuation->wakeOnResult();

--- a/proofs/functional.php
+++ b/proofs/functional.php
@@ -35,7 +35,7 @@ return static function() {
                                 static fn($os) => $os->process()->halt(Period::second(1))->unwrap(),
                                 static fn($os) => $os->process()->halt(Period::second(1))->unwrap(),
                             ))
-                            ->terminate(),
+                            ->finish(),
                     );
             });
             $expect
@@ -56,7 +56,7 @@ return static function() {
         static function($assert, $initial, $modified) {
             $returned = Scheduler::of(Factory::build())
                 ->sink($initial)
-                ->with(static fn($_, $__, $continuation) => $continuation->terminate());
+                ->with(static fn($_, $__, $continuation) => $continuation->finish());
             $assert->same($initial, $returned);
 
             $returned = Scheduler::of(Factory::build())
@@ -64,7 +64,7 @@ return static function() {
                 ->with(
                     static fn($carry, $__, $continuation) => $continuation
                         ->carryWith($initial)
-                        ->terminate(),
+                        ->finish(),
                 );
             $assert->same($initial, $returned);
 
@@ -73,7 +73,7 @@ return static function() {
                 ->with(
                     static fn($carry, $__, $continuation) => $continuation
                         ->carryWith($modified)
-                        ->terminate(),
+                        ->finish(),
                 );
             $assert->same($modified, $returned);
         },
@@ -131,7 +131,7 @@ return static function() {
 
                                 return $continuation;
                             })($os, $continuation),
-                            default => $continuation->terminate(),
+                            default => $continuation->finish(),
                         },
                     );
             });
@@ -160,7 +160,7 @@ return static function() {
                                     ->unwrap();
                                 $results[] = 'scope';
 
-                                return $continuation->terminate();
+                                return $continuation->finish();
                             }
 
                             return $continuation
@@ -220,7 +220,7 @@ return static function() {
                                     ->unwrap();
                                 $results[] = 'scope';
 
-                                return $continuation->terminate();
+                                return $continuation->finish();
                             }
 
                             return $continuation
@@ -326,7 +326,7 @@ return static function() {
                                         );
                                 },
                             ))
-                            ->terminate();
+                            ->finish();
                     },
                 );
             $assert->same(
@@ -387,7 +387,7 @@ return static function() {
                                         );
                                 },
                             ))
-                            ->terminate();
+                            ->finish();
                     },
                 );
             // since the license file is shorter it finishes first even though
@@ -439,7 +439,7 @@ return static function() {
                                     $order[] = 'second';
                                 },
                             ))
-                            ->terminate();
+                            ->finish();
                     },
                 );
 
@@ -493,7 +493,7 @@ return static function() {
                                             ->unwrap(),
                                     ),
                                 )
-                                ->terminate(),
+                                ->finish(),
                         );
                 })
                 ->inLessThan()

--- a/proofs/functional.php
+++ b/proofs/functional.php
@@ -547,7 +547,7 @@ return static function() {
                                 ->halt(Period::second(1))
                                 ->unwrap();
 
-                            return $continuation->abort();
+                            return $continuation->terminate();
                         },
                     );
             });

--- a/src/Scheduler/State.php
+++ b/src/Scheduler/State.php
@@ -10,7 +10,7 @@ use Innmind\Async\{
     Scope\Restartable,
     Scope\Wakeable,
     Scope\Aborted,
-    Scope\Terminated,
+    Scope\Finished,
     Wait,
     Config,
 };
@@ -24,11 +24,11 @@ use Innmind\Immutable\Sequence;
 final class State
 {
     /**
-     * @param Uninitialized<C>|Suspended<C>|Resumable<C>|Restartable<C>|Wakeable<C>|Aborted<C>|Terminated<C> $scope
+     * @param Uninitialized<C>|Suspended<C>|Resumable<C>|Restartable<C>|Wakeable<C>|Aborted<C>|Finished<C> $scope
      * @param Sequence<mixed> $results
      */
     private function __construct(
-        private Uninitialized|Suspended|Resumable|Restartable|Wakeable|Aborted|Terminated $scope,
+        private Uninitialized|Suspended|Resumable|Restartable|Wakeable|Aborted|Finished $scope,
         private Tasks $tasks,
         private Sequence $results,
         private Config\Provider $config,
@@ -85,7 +85,7 @@ final class State
     }
 
     /**
-     * @return array{self<C>, Aborted<C>|Terminated<C>|null}
+     * @return array{self<C>, Aborted<C>|Finished<C>|null}
      */
     #[\NoDiscard]
     public function wait(
@@ -93,7 +93,7 @@ final class State
         Wait $wait,
     ): array {
         if (
-            $this->scope instanceof Terminated &&
+            $this->scope instanceof Finished &&
             $this->tasks->empty()
         ) {
             return [$this, $this->scope];
@@ -111,7 +111,7 @@ final class State
             $this->tasks->empty() &&
             $this->results->empty()
         ) {
-            return [$this, $this->scope->terminate()];
+            return [$this, $this->scope->finish()];
         }
 
         if ($this->scope instanceof Suspended) {
@@ -172,19 +172,19 @@ final class State
                 ),
             },
             $this->scope instanceof Aborted => $this->scope,
-            $this->scope instanceof Terminated => $this->scope->next(),
+            $this->scope instanceof Finished => $this->scope->next(),
         };
         $results = match (true) {
             $this->scope instanceof Restartable => $this->results->clear(),
             $this->scope instanceof Wakeable => $this->results->clear(),
             $this->scope instanceof Aborted => $this->results->clear(),
-            $this->scope instanceof Terminated => $this->results->clear(),
+            $this->scope instanceof Finished => $this->results->clear(),
             default => $this->results,
         };
         $newTasks = match (true) {
             $scope instanceof Restartable => $scope->tasks(),
             $scope instanceof Wakeable => $scope->tasks(),
-            $scope instanceof Terminated => $scope->tasks(),
+            $scope instanceof Finished => $scope->tasks(),
             default => Sequence::of(),
         };
 

--- a/src/Scope/Continuation.php
+++ b/src/Scope/Continuation.php
@@ -110,10 +110,10 @@ final class Continuation
      * @return self<C>
      */
     #[\NoDiscard]
-    public function abort(): self
+    public function terminate(): self
     {
         return new self(
-            Next::abort,
+            Next::terminate,
             $this->tasks->clear(),
             $this->carry,
         );
@@ -128,7 +128,7 @@ final class Continuation
      *
      * @param pure-callable(Sequence<callable(OperatingSystem)>, C): T $restart
      * @param pure-callable(Sequence<callable(OperatingSystem)>, C): U $wake
-     * @param pure-callable(C): V $abort
+     * @param pure-callable(C): V $terminate
      * @param pure-callable(Sequence<callable(OperatingSystem)>, C): W $finish
      *
      * @return T|U|V|W
@@ -137,13 +137,13 @@ final class Continuation
     public function match(
         callable $restart,
         callable $wake,
-        callable $abort,
+        callable $terminate,
         callable $finish,
     ): mixed {
         return match ($this->next) {
             Next::restart => $restart($this->tasks, $this->carry),
             Next::wake => $wake($this->tasks, $this->carry),
-            Next::abort => $abort($this->carry),
+            Next::terminate => $terminate($this->carry),
             Next::finish => $finish($this->tasks, $this->carry),
         };
     }

--- a/src/Scope/Continuation.php
+++ b/src/Scope/Continuation.php
@@ -81,10 +81,10 @@ final class Continuation
      * @return self<C>
      */
     #[\NoDiscard]
-    public function terminate(): self
+    public function finish(): self
     {
         return new self(
-            Next::terminate,
+            Next::finish,
             $this->tasks,
             $this->carry,
         );
@@ -129,7 +129,7 @@ final class Continuation
      * @param pure-callable(Sequence<callable(OperatingSystem)>, C): T $restart
      * @param pure-callable(Sequence<callable(OperatingSystem)>, C): U $wake
      * @param pure-callable(C): V $abort
-     * @param pure-callable(Sequence<callable(OperatingSystem)>, C): W $terminate
+     * @param pure-callable(Sequence<callable(OperatingSystem)>, C): W $finish
      *
      * @return T|U|V|W
      */
@@ -138,13 +138,13 @@ final class Continuation
         callable $restart,
         callable $wake,
         callable $abort,
-        callable $terminate,
+        callable $finish,
     ): mixed {
         return match ($this->next) {
             Next::restart => $restart($this->tasks, $this->carry),
             Next::wake => $wake($this->tasks, $this->carry),
             Next::abort => $abort($this->carry),
-            Next::terminate => $terminate($this->tasks, $this->carry),
+            Next::finish => $finish($this->tasks, $this->carry),
         };
     }
 }

--- a/src/Scope/Continuation/Next.php
+++ b/src/Scope/Continuation/Next.php
@@ -11,6 +11,6 @@ enum Next
 {
     case restart;
     case wake;
-    case abort;
+    case terminate;
     case finish;
 }

--- a/src/Scope/Continuation/Next.php
+++ b/src/Scope/Continuation/Next.php
@@ -12,5 +12,5 @@ enum Next
     case restart;
     case wake;
     case abort;
-    case terminate;
+    case finish;
 }

--- a/src/Scope/Finished.php
+++ b/src/Scope/Finished.php
@@ -13,7 +13,7 @@ use Innmind\Immutable\Sequence;
  * @psalm-immutable
  * @template C
  */
-final class Terminated
+final class Finished
 {
     /**
      * @param Sequence<callable(OperatingSystem)> $tasks

--- a/src/Scope/Restartable.php
+++ b/src/Scope/Restartable.php
@@ -50,13 +50,13 @@ final class Restartable
     /**
      * @param Sequence<mixed> $results
      *
-     * @return Suspended<C>|self<C>|Wakeable<C>|Aborted<C>|Finished<C>
+     * @return Suspended<C>|self<C>|Wakeable<C>|Terminated<C>|Finished<C>
      */
     #[\NoDiscard]
     public function next(
         OperatingSystem $async,
         Sequence $results,
-    ): Suspended|self|Wakeable|Aborted|Finished {
+    ): Suspended|self|Wakeable|Terminated|Finished {
         $fiber = $this->scope->new();
         $return = Suspension::of($fiber->start(
             $this->carry,
@@ -79,7 +79,7 @@ final class Restartable
         return $continuation->match(
             self::of($this->scope),
             Wakeable::of($this->scope),
-            Aborted::of(...),
+            Terminated::of(...),
             Finished::of(...),
         );
     }

--- a/src/Scope/Restartable.php
+++ b/src/Scope/Restartable.php
@@ -50,13 +50,13 @@ final class Restartable
     /**
      * @param Sequence<mixed> $results
      *
-     * @return Suspended<C>|self<C>|Wakeable<C>|Aborted<C>|Terminated<C>
+     * @return Suspended<C>|self<C>|Wakeable<C>|Aborted<C>|Finished<C>
      */
     #[\NoDiscard]
     public function next(
         OperatingSystem $async,
         Sequence $results,
-    ): Suspended|self|Wakeable|Aborted|Terminated {
+    ): Suspended|self|Wakeable|Aborted|Finished {
         $fiber = $this->scope->new();
         $return = Suspension::of($fiber->start(
             $this->carry,
@@ -80,7 +80,7 @@ final class Restartable
             self::of($this->scope),
             Wakeable::of($this->scope),
             Aborted::of(...),
-            Terminated::of(...),
+            Finished::of(...),
         );
     }
 

--- a/src/Scope/Resumable.php
+++ b/src/Scope/Resumable.php
@@ -40,10 +40,10 @@ final class Resumable
     }
 
     /**
-     * @return Suspended<C>|Restartable<C>|Wakeable<C>|Aborted<C>|Finished<C>
+     * @return Suspended<C>|Restartable<C>|Wakeable<C>|Terminated<C>|Finished<C>
      */
     #[\NoDiscard]
-    public function next(): Suspended|Restartable|Wakeable|Aborted|Finished
+    public function next(): Suspended|Restartable|Wakeable|Terminated|Finished
     {
         $return = Suspension::of($this->fiber->resume(
             $this->resumption->unwrap(),
@@ -63,7 +63,7 @@ final class Resumable
         return $continuation->match(
             Restartable::of($this->scope),
             Wakeable::of($this->scope),
-            Aborted::of(...),
+            Terminated::of(...),
             Finished::of(...),
         );
     }

--- a/src/Scope/Resumable.php
+++ b/src/Scope/Resumable.php
@@ -40,10 +40,10 @@ final class Resumable
     }
 
     /**
-     * @return Suspended<C>|Restartable<C>|Wakeable<C>|Aborted<C>|Terminated<C>
+     * @return Suspended<C>|Restartable<C>|Wakeable<C>|Aborted<C>|Finished<C>
      */
     #[\NoDiscard]
-    public function next(): Suspended|Restartable|Wakeable|Aborted|Terminated
+    public function next(): Suspended|Restartable|Wakeable|Aborted|Finished
     {
         $return = Suspension::of($this->fiber->resume(
             $this->resumption->unwrap(),
@@ -64,7 +64,7 @@ final class Resumable
             Restartable::of($this->scope),
             Wakeable::of($this->scope),
             Aborted::of(...),
-            Terminated::of(...),
+            Finished::of(...),
         );
     }
 }

--- a/src/Scope/Terminated.php
+++ b/src/Scope/Terminated.php
@@ -10,7 +10,7 @@ namespace Innmind\Async\Scope;
  * @psalm-immutable
  * @template C
  */
-final class Aborted
+final class Terminated
 {
     /**
      * @param C $carry

--- a/src/Scope/Uninitialized.php
+++ b/src/Scope/Uninitialized.php
@@ -42,10 +42,10 @@ final class Uninitialized
     }
 
     /**
-     * @return Suspended<C>|Restartable<C>|Wakeable<C>|Aborted<C>|Terminated<C>
+     * @return Suspended<C>|Restartable<C>|Wakeable<C>|Aborted<C>|Finished<C>
      */
     #[\NoDiscard]
-    public function next(OperatingSystem $async): Suspended|Restartable|Wakeable|Aborted|Terminated
+    public function next(OperatingSystem $async): Suspended|Restartable|Wakeable|Aborted|Finished
     {
         $fiber = $this->scope->new();
         $return = Suspension::of($fiber->start(
@@ -70,7 +70,7 @@ final class Uninitialized
             Restartable::of($this->scope),
             Wakeable::of($this->scope),
             Aborted::of(...),
-            Terminated::of(...),
+            Finished::of(...),
         );
     }
 }

--- a/src/Scope/Uninitialized.php
+++ b/src/Scope/Uninitialized.php
@@ -42,10 +42,10 @@ final class Uninitialized
     }
 
     /**
-     * @return Suspended<C>|Restartable<C>|Wakeable<C>|Aborted<C>|Finished<C>
+     * @return Suspended<C>|Restartable<C>|Wakeable<C>|Terminated<C>|Finished<C>
      */
     #[\NoDiscard]
-    public function next(OperatingSystem $async): Suspended|Restartable|Wakeable|Aborted|Finished
+    public function next(OperatingSystem $async): Suspended|Restartable|Wakeable|Terminated|Finished
     {
         $fiber = $this->scope->new();
         $return = Suspension::of($fiber->start(
@@ -69,7 +69,7 @@ final class Uninitialized
         return $continuation->match(
             Restartable::of($this->scope),
             Wakeable::of($this->scope),
-            Aborted::of(...),
+            Terminated::of(...),
             Finished::of(...),
         );
     }

--- a/src/Scope/Wakeable.php
+++ b/src/Scope/Wakeable.php
@@ -51,13 +51,13 @@ final class Wakeable
     /**
      * @param Sequence<mixed> $results
      *
-     * @return Suspended<C>|Restartable<C>|self<C>|Aborted<C>|Finished<C>
+     * @return Suspended<C>|Restartable<C>|self<C>|Terminated<C>|Finished<C>
      */
     #[\NoDiscard]
     public function next(
         OperatingSystem $async,
         Sequence $results,
-    ): Suspended|Restartable|self|Aborted|Finished {
+    ): Suspended|Restartable|self|Terminated|Finished {
         $fiber = $this->scope->new();
         $return = Suspension::of($fiber->start(
             $this->carry,
@@ -80,7 +80,7 @@ final class Wakeable
         return $continuation->match(
             Restartable::of($this->scope),
             self::of($this->scope),
-            Aborted::of(...),
+            Terminated::of(...),
             Finished::of(...),
         );
     }

--- a/src/Scope/Wakeable.php
+++ b/src/Scope/Wakeable.php
@@ -51,13 +51,13 @@ final class Wakeable
     /**
      * @param Sequence<mixed> $results
      *
-     * @return Suspended<C>|Restartable<C>|self<C>|Aborted<C>|Terminated<C>
+     * @return Suspended<C>|Restartable<C>|self<C>|Aborted<C>|Finished<C>
      */
     #[\NoDiscard]
     public function next(
         OperatingSystem $async,
         Sequence $results,
-    ): Suspended|Restartable|self|Aborted|Terminated {
+    ): Suspended|Restartable|self|Aborted|Finished {
         $fiber = $this->scope->new();
         $return = Suspension::of($fiber->start(
             $this->carry,
@@ -81,7 +81,7 @@ final class Wakeable
             Restartable::of($this->scope),
             self::of($this->scope),
             Aborted::of(...),
-            Terminated::of(...),
+            Finished::of(...),
         );
     }
 
@@ -98,12 +98,12 @@ final class Wakeable
     }
 
     /**
-     * @return Terminated<C>
+     * @return Finished<C>
      */
     #[\NoDiscard]
-    public function terminate(): Terminated
+    public function finish(): Finished
     {
-        return Terminated::of(
+        return Finished::of(
             $this->tasks->clear(),
             $this->carry,
         );


### PR DESCRIPTION
`Terminate` was misleading and wasn't aligned to the old `abort`  that send the `Signal::terminate`.