### PR TITLE
Rename `Continuation::wakeOnResult()` to `::wake()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Requires `innmind/operating-system:~7.0`
 - Requires `innmind/time:~1.0`
 - Tasks results are now accessible via `Continuation::results()` instead of scope's fourth argument
+- `Continuation::wakeOnResult()` has been renamed `::wake()`

--- a/proofs/functional.php
+++ b/proofs/functional.php
@@ -97,7 +97,7 @@ return static function() {
                             default => Sequence::of(),
                         })
                         ->carryWith($all->append($continuation->results()))
-                        ->wakeOnResult(),
+                        ->wake(),
                 );
             $assert->same([$value], $values->toList());
         },
@@ -466,7 +466,7 @@ return static function() {
                             static fn($os) => $os->process()->halt(Period::second(1))->unwrap(),
                         )->map(Task\Discard::result(...)))
                         ->carryWith($all->append($continuation->results()))
-                        ->wakeOnResult(),
+                        ->wake(),
                 );
 
             $assert->same(0, $results->size());

--- a/src/Scope/Continuation.php
+++ b/src/Scope/Continuation.php
@@ -109,7 +109,7 @@ final class Continuation
      * @return self<C>
      */
     #[\NoDiscard]
-    public function wakeOnResult(): self
+    public function wake(): self
     {
         return new self(
             Next::wake,


### PR DESCRIPTION
This is in preparation for #10 has it will wake the scope on notifications.